### PR TITLE
Respect showCoverageOnHover option when processing cluster options

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -327,13 +327,13 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
             } );
         }
 
+        // Fix for issue: https://github.com/bcgov/smk/issues/104.
         if (viewer &&
             viewer.clusterOption &&
             viewer.clusterOption.showCoverageOnHover !== undefined) {
             opt.showCoverageOnHover = viewer.clusterOption.showCoverageOnHover;
         }
         
-
         return opt
     }
 } )

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -327,6 +327,13 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
             } );
         }
 
+        if (viewer &&
+            viewer.clusterOption &&
+            viewer.clusterOption.showCoverageOnHover !== undefined) {
+            opt.showCoverageOnHover = viewer.clusterOption.showCoverageOnHover;
+        }
+        
+
         return opt
     }
 } )


### PR DESCRIPTION
Fix [#104](https://github.com/bcgov/smk/issues/104).

Instructions for reproducing/testing the bug are available in the linked issue.
