### PR TITLE
showCoverageOnHover can be read from a vector layer

### DIFF
--- a/docs/configuration/layers/cluster-option.md
+++ b/docs/configuration/layers/cluster-option.md
@@ -1,0 +1,20 @@
+###### [SMK](../../..) / [Configuration](..) / [Layers](.)
+
+# Layer Cluster Option Objects
+
+This object defines properties that influence the rendering of clusters of points.
+
+A clusterOption object contains these properties, which have these default values. 
+Click on a property name for more information:
+<pre>
+{
+    <a href="#showcoverageonhover-property"          >"showCoverageOnHover"</a>:          false
+}
+</pre>
+
+
+## ShowCoverageOnHover Property
+`"showCoverageOnHover": Boolean`
+
+If `true`, then the bounds of a cluster's markers show when you hover over the cluster.
+The default value is `false`.

--- a/docs/configuration/layers/style.md
+++ b/docs/configuration/layers/style.md
@@ -8,7 +8,7 @@ When multiple styles are defined, then each feature in the layer is rendered in 
 
 If a point feature is being rendered, the `"marker..."` properties are used. If the [`"markerUrl"` property](#markerurl-property) isn't defined, then a circle is rendered instead, using the `"stroke..."` and `"fill..."` properties. The circle radius will be half of the [`"strokeWidth"` property](#strokewidth-property).
 
-A style object contains is defined with these properties, which have these default values.
+A style object contains these properties, which have these default values. 
 Click on a property name for more information:
 <pre>
 {

--- a/docs/configuration/layers/vector.md
+++ b/docs/configuration/layers/vector.md
@@ -20,6 +20,7 @@ Click on a property name for more information:
     <a href="#attributes-property"          >"attributes"</a>:          null,
     <a href="#queries-property"             >"queries"</a>:             null,
     <a href="#useclustering-property"       >"useClustering"</a>:       false,
+    <a href="#clusteroption-property"       >"clusterOption"</a>:       null,
     <a href="#useheatmap-property"          >"useHeatmap"</a>:          false,
     <a href="#style-property"               >"style"</a>:               null,
     <a href="#dataUrl-property"             >"dataUrl"</a>:             null
@@ -48,6 +49,11 @@ If `true`, the layer should use point clustering.
 Only relevant for point geometry layers.
 The default is `false`.
 
+
+## ClusterOption Property
+`"clusterOption": Object`
+
+The [cluster option](cluster-option) object used to influence the rendering of clusters of points.
 
 ## UseHeatmap Property
 `"useHeatmap": Boolean`

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -310,11 +310,24 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
     function clusterOptions( layerConfig, viewer ) {
         var opt = {}
 
-        // Fix for issue: https://github.com/bcgov/smk/issues/104
+        // Set showCoverageOnHover from the layer if a value exists
+        if ( layerConfig && 
+            layerConfig.clusterOption &&
+            layerConfig.clusterOption.showCoverageOnHover !== undefined) {
+                opt.showCoverageOnHover = layerConfig.clusterOption.showCoverageOnHover;
+        }
+
+        // For backwards compatibility, override showCoverageOnHover with
+        // a 'true' value from the viewer.
         if ( viewer &&
             viewer.clusterOption &&
-            viewer.clusterOption.showCoverageOnHover !== undefined ) {
-            opt.showCoverageOnHover = viewer.clusterOption.showCoverageOnHover;
+            !!viewer.clusterOption.showCoverageOnHover ) { 
+                opt.showCoverageOnHover = viewer.clusterOption.showCoverageOnHover;
+        }
+
+        // If no value has been set, set to a default of 'false'.
+        if (opt.showCoverageOnHover === undefined) {
+            opt.showCoverageOnHover = false;
         }
 
         if ( layerConfig && layerConfig.clusterStyle ) {

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -310,19 +310,19 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
     function clusterOptions( layerConfig, viewer ) {
         var opt = {}
 
-        // Set showCoverageOnHover from the layer if a value exists
-        if ( layerConfig && 
-            layerConfig.clusterOption &&
-            layerConfig.clusterOption.showCoverageOnHover !== undefined) {
-                opt.showCoverageOnHover = layerConfig.clusterOption.showCoverageOnHover;
-        }
-
-        // For backwards compatibility, override showCoverageOnHover with
+        // For backwards compatibility, set showCoverageOnHover with
         // a 'true' value from the viewer.
         if ( viewer &&
             viewer.clusterOption &&
             !!viewer.clusterOption.showCoverageOnHover ) { 
                 opt.showCoverageOnHover = viewer.clusterOption.showCoverageOnHover;
+        }
+
+        // Override showCoverageOnHover with a value from the layer if one exists
+        if ( layerConfig && 
+            layerConfig.clusterOption &&
+            layerConfig.clusterOption.showCoverageOnHover !== undefined) {
+                opt.showCoverageOnHover = layerConfig.clusterOption.showCoverageOnHover;
         }
 
         // If no value has been set, set to a default of 'false'.


### PR DESCRIPTION
This change allows smk to read a "showCoverageOnHover" value from a vector layer's "layer" element in smk-config.json. This change is a companion to a change in smk-cli that will add a UI control to turn the functionality on or off for a vector layer (https://github.com/bcgov/smk-cli/issues/63).

showCoverageOnHover can currently be read from the "viewer" element of smk-config.json. This allows a true value in the viewer to override a value in the layer.

If no value is set in a vector layer or in the viewer, the default value of 'false' is used.

###Suggested Test Procedure 

- Create/use an app using smk-cli
- Add a vector layer having points (Example:
https://openmaps.gov.bc.ca/geo/pub/WHSE_IMAGERY_AND_BASE_MAPS.GSR_ASSISTED_LIVING_LOCS_SV/ows?service=WMS&request=GetMap&version=1.1.1&layers=pub:WHSE_IMAGERY_AND_BASE_MAPS.GSR_ASSISTED_LIVING_LOCS_SV&format=application/json;type=geojson&transparent=true&cql_filter=include&srs=EPSG%3A4326&width=645&height=728&bbox=-144.19403793672322,45.39637993438814,-108.99384262912152,62.632414448856416)
- From smk:
-- check out these changes
-- run 'npm start' to copy changes from /src to /dist
-- run 'npm link' to link these changes to the global node modules
- From the directory of the app built with smk-cli:
-- run 'npm run view' to start the app and launch it in a browser
- Edit the smk app's smk-config.json and test different values for showCoverageOnHover in the "layer" element that has the vector layer as well as the "viewer" element
snippet:
"clusterOption": {
  "showCoverageOnHover": true
}
- Confirm that a hover over a cluster behaves as expected
- Test true, false, and no value (clusterOption, showCoverageOnHover elements removed)
- showCoverageOnHover should be false by default
- If a 'true' value for showCoverageOnHover is set in the viewer, it should be used
- If a value for showCoverageOnHover is set in the layer, it should be used and override any value in the viewer
