### PR TITLE
package-lock.json added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 **/.vscode/**
 **/.settings/**
 
+# Generated files
+package-lock.json
+
 # Generated dirs
 **/node_modules/**
 **/target/**


### PR DESCRIPTION
This adds the package-lock.json file to .gitignore. package-lock.json is a generated file that is updated by changes in the node module tree or package.json. It is not in source control but because it changes frequently, it appears among other deliberately changed files that are in source control.