### PR TITLE
Proof of concept: different path styles for Markup, Geomark tools

### DIFF
--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -109,14 +109,24 @@ include.module( 'tool-geomark', [
                 }
             } 
 
+            this.defaultTemplineStyle = undefined;
+            this.defaultHintlineStyle = undefined;
             this.changedActive( function () {
                 if ( self.active ) {
+                    if (!this.defaultTemplineStyle) {
+                        this.defaultTemplineStyle = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().templineStyle));
+                    }
+                    if (!this.defaultHintlineStyle) {
+                        this.defaultHintlineStyle = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().hintlineStyle));
+                    }
+                    smk.$viewer.map.pm.setGlobalOptions({ templineStyle: { color: 'black' }, hintlineStyle: { color: 'green' } });
                     smk.$viewer.map.pm.enableDraw('Polygon', {
                         continueDrawing: true
                     });
                 }
                 else {
                     smk.$viewer.map.pm.disableDraw();
+                    smk.$viewer.map.pm.setGlobalOptions({ templineStyle: this.defaultTemplineStyle, hintlineStyle: this.defaultHintlineStyle });
                 }
             } )
 

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -110,23 +110,16 @@ include.module( 'tool-geomark', [
             } 
 
             this.setCurrentDrawingLayer = function(e) {
-                currentDrawingLayer.addLayer(e.layer);
+                var eventLayer = e.layer;
+                eventLayer.pm.setOptions( {
+                    'allowEditing': false,
+                    'allowRemoval': false
+                } );
+                currentDrawingLayer.addLayer(eventLayer);
             }
 
-            this.defaultTemplineStyle = undefined;
-            this.defaultHintlineStyle = undefined;
-            this.defaultPathOptions = undefined;
             this.changedActive( function () {
                 if ( self.active ) {
-                    if (!this.defaultTemplineStyle) {
-                        this.defaultTemplineStyle = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().templineStyle));
-                    }
-                    if (!this.defaultHintlineStyle) {
-                        this.defaultHintlineStyle = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().hintlineStyle));
-                    }
-                    if (!this.defaultPathOptions) {
-                        this.defaultPathOptions = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().pathOptions));
-                    }
                     smk.$viewer.map.pm.setGlobalOptions({ 
                         templineStyle: { 
                             color: '#003366' 
@@ -147,12 +140,8 @@ include.module( 'tool-geomark', [
                 }
                 else {
                     smk.$viewer.map.pm.disableDraw();
-                    smk.$viewer.map.on('pm:create', undefined); // FIXME polygons drawn by Markup still trigger self.setCurrentDrawingLayer 
-                    smk.$viewer.map.pm.setGlobalOptions({ 
-                        templineStyle: this.defaultTemplineStyle, 
-                        hintlineStyle: this.defaultHintlineStyle,
-                        pathOptions: this.defaultPathOptions
-                    });
+                    smk.$viewer.map.off('pm:create', self.setCurrentDrawingLayer);
+                    self.setDefaultDrawStyle();
                 }
             } )
 

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -122,15 +122,15 @@ include.module( 'tool-geomark', [
                 if ( self.active ) {
                     smk.$viewer.map.pm.setGlobalOptions({ 
                         templineStyle: { 
-                            color: '#003366' 
+                            color: '#ee0077' 
                         }, 
                         hintlineStyle: { 
-                            color: '#003366',
+                            color: '#ee0077',
                             fill: false,
                             dashArray: [5, 5] 
                         },
                         pathOptions: {
-                            color: '#003366'
+                            color: '#ee0077'
                         } 
                     });
                     smk.$viewer.map.on('pm:create', self.setCurrentDrawingLayer);

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -109,8 +109,13 @@ include.module( 'tool-geomark', [
                 }
             } 
 
+            this.setCurrentDrawingLayer = function(e) {
+                currentDrawingLayer.addLayer(e.layer);
+            }
+
             this.defaultTemplineStyle = undefined;
             this.defaultHintlineStyle = undefined;
+            this.defaultPathOptions = undefined;
             this.changedActive( function () {
                 if ( self.active ) {
                     if (!this.defaultTemplineStyle) {
@@ -119,14 +124,35 @@ include.module( 'tool-geomark', [
                     if (!this.defaultHintlineStyle) {
                         this.defaultHintlineStyle = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().hintlineStyle));
                     }
-                    smk.$viewer.map.pm.setGlobalOptions({ templineStyle: { color: 'black' }, hintlineStyle: { color: 'green' } });
+                    if (!this.defaultPathOptions) {
+                        this.defaultPathOptions = JSON.parse(JSON.stringify(smk.$viewer.map.pm.getGlobalOptions().pathOptions));
+                    }
+                    smk.$viewer.map.pm.setGlobalOptions({ 
+                        templineStyle: { 
+                            color: '#003366' 
+                        }, 
+                        hintlineStyle: { 
+                            color: '#003366',
+                            fill: false,
+                            dashArray: [5, 5] 
+                        },
+                        pathOptions: {
+                            color: '#003366'
+                        } 
+                    });
+                    smk.$viewer.map.on('pm:create', self.setCurrentDrawingLayer);
                     smk.$viewer.map.pm.enableDraw('Polygon', {
                         continueDrawing: true
                     });
                 }
                 else {
                     smk.$viewer.map.pm.disableDraw();
-                    smk.$viewer.map.pm.setGlobalOptions({ templineStyle: this.defaultTemplineStyle, hintlineStyle: this.defaultHintlineStyle });
+                    smk.$viewer.map.on('pm:create', undefined); // FIXME polygons drawn by Markup still trigger self.setCurrentDrawingLayer 
+                    smk.$viewer.map.pm.setGlobalOptions({ 
+                        templineStyle: this.defaultTemplineStyle, 
+                        hintlineStyle: this.defaultHintlineStyle,
+                        pathOptions: this.defaultPathOptions
+                    });
                 }
             } )
 
@@ -185,10 +211,6 @@ include.module( 'tool-geomark', [
             this.openGeomarkFileWindow = function() {
                 window.open(self.geomarkService.url + '/geomarks#file');
             }
-
-            smk.$viewer.map.on('pm:create', function(e) {
-                currentDrawingLayer.addLayer(e.layer);
-            });
 
             var client = new window.GeomarkClient(self.geomarkService.url);
 

--- a/src/smk/tool/tool-base.js
+++ b/src/smk/tool/tool-base.js
@@ -126,6 +126,22 @@ include.module( 'tool.tool-base-js', [ 'tool.tool-js' ], function ( inc ) {
                 return smk.getStatusMessage().show( message, status, delay, this.busy )
             }
 
+            this.setDefaultDrawStyle = function() {
+                smk.$viewer.map.pm.setGlobalOptions({ 
+                    templineStyle: { 
+                        color: 'red',
+                        fill: false
+                    }, 
+                    hintlineStyle: { 
+                        color: 'red',
+                        fill: false,
+                        dashArray: [5, 5] 
+                    },
+                    pathOptions: {
+                        color: '#3388ff'
+                    } 
+                });
+            }
         } )
 
         this.isToolInGroupActive = function ( toolId ) {

--- a/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
+++ b/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
@@ -4,7 +4,20 @@ include.module( 'tool-markup-leaflet', [ 'leaflet', 'tool-markup' ], function ()
     SMK.TYPE.MarkupTool.addInitializer( function ( smk ) {
         if ( smk.$device == 'mobile' ) return
 
-        smk.$viewer.map.pm.setGlobalOptions({ templineStyle: { color: 'purple' }, hintlineStyle: { color: 'orange', dashArray: [15, 5] } });
+        smk.$viewer.map.pm.setGlobalOptions({ 
+            templineStyle: { 
+                color: 'red',
+                fill: false
+            }, 
+            hintlineStyle: { 
+                color: 'red',
+                fill: false,
+                dashArray: [5, 5] 
+            },
+            pathOptions: {
+                color: '#3388ff'
+            } 
+        });
 
         smk.$viewer.map.pm.addControls( {
             // Options are defined in https://github.com/geoman-io/leaflet-geoman#leaflet-geoman-toolbar

--- a/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
+++ b/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
@@ -4,6 +4,8 @@ include.module( 'tool-markup-leaflet', [ 'leaflet', 'tool-markup' ], function ()
     SMK.TYPE.MarkupTool.addInitializer( function ( smk ) {
         if ( smk.$device == 'mobile' ) return
 
+        smk.$viewer.map.pm.setGlobalOptions({ templineStyle: { color: 'purple' }, hintlineStyle: { color: 'orange', dashArray: [15, 5] } });
+
         smk.$viewer.map.pm.addControls( {
             // Options are defined in https://github.com/geoman-io/leaflet-geoman#leaflet-geoman-toolbar
             position: 'topright', 
@@ -12,6 +14,6 @@ include.module( 'tool-markup-leaflet', [ 'leaflet', 'tool-markup' ], function ()
             dragMode: false,
             cutPolygon: false,
             rotateMode: false
-        } )
+        } );
     } )
 } )

--- a/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
+++ b/src/smk/viewer-leaflet/tool/markup/tool-markup-leaflet.js
@@ -4,20 +4,7 @@ include.module( 'tool-markup-leaflet', [ 'leaflet', 'tool-markup' ], function ()
     SMK.TYPE.MarkupTool.addInitializer( function ( smk ) {
         if ( smk.$device == 'mobile' ) return
 
-        smk.$viewer.map.pm.setGlobalOptions({ 
-            templineStyle: { 
-                color: 'red',
-                fill: false
-            }, 
-            hintlineStyle: { 
-                color: 'red',
-                fill: false,
-                dashArray: [5, 5] 
-            },
-            pathOptions: {
-                color: '#3388ff'
-            } 
-        });
+        this.setDefaultDrawStyle();
 
         smk.$viewer.map.pm.addControls( {
             // Options are defined in https://github.com/geoman-io/leaflet-geoman#leaflet-geoman-toolbar


### PR DESCRIPTION
This demonstrates the ability to have unique path styles for a tool.

The Markup tool is treated as a default draw tool. It is updated to set default styles for the temp line and hint line. The Geomark tool is updated to capture these styles when entered and set different styles; on exit, it restores the default styles.

Darren, please let me know what you think of this approach. 

I'm not sure it's worth the effort as it adds complexity that we'd have to maintain going forward, and could potentially complicate other future changes.