### PR TITLE
Create From File link is configurable

### DIFF
--- a/docs/configuration/tools/geomark.md
+++ b/docs/configuration/tools/geomark.md
@@ -45,4 +45,4 @@ The URL of the geomark web service used.
 ## Enable Create From File Property
 `"enableCreateFromFile"`: `Boolean`
 
-When set to true, a link will be added to the panel that opens a new browser tab to the page of the geomark service where a file can be uploaded to create a new geomark. The geomark's link can then be used to load a geomark.
+When true, the panel will contain a link to the Geomark service where a file can be uploaded to create a new geomark. The geomark can then be added to the map by loading it.

--- a/docs/configuration/tools/geomark.md
+++ b/docs/configuration/tools/geomark.md
@@ -16,6 +16,7 @@ This is default configuration for the Geomark tool (click on a property name for
     <a href="#geomark-service-property">"geomarkService"</a>: {
         <a href="#url-sub-property">"url"</a>:            "https://apps.gov.bc.ca/pub/geomark"
     },
+    <a href="#enable-create-from-file-property">"enableCreateFromFile"</a>: false,
     <a href="#enabled-property">"enabled"</a>:        false,
     <a href="#icon-property"     >"icon"</a>:           <a href="https://material.io/tools/icons/?icon=build" target="material">"build"</a>,
     <a href="#order-property"    >"order"</a>:          1,
@@ -40,3 +41,8 @@ Contains properties of the geomark web service.
 `"geomarkService"`: `{ "url": String }`
 
 The URL of the geomark web service used.
+
+## Enable Create From File Property
+`"enableCreateFromFile"`: `Boolean`
+
+When set to true, a link will be added to the panel that opens a new browser tab to the page of the geomark service where a file can be uploaded to create a new geomark. The geomark's link can then be used to load a geomark.

--- a/src/smk/tool/geomark/panel-geomark.html
+++ b/src/smk/tool/geomark/panel-geomark.html
@@ -17,7 +17,7 @@
         <li><a href="#" v-on:click="$$emit( 'create-geomark-from-drawing' )">Save Drawing as Geomark</a></li>
         <li><a href="#" v-on:click="$$emit( 'clear-drawing' )">Clear Current Drawing</a></li>
         <li><a href="#" v-on:click="$$emit( 'load-geomark' )">Load an Existing Geomark</a></li>
-        <li><a href="#" v-on:click="$$emit( 'create-geomark-from-file' )">Create a Geomark from File</a></li>
+        <li v-if="enableCreateFromFile === true"><a href="#" v-on:click="$$emit( 'create-geomark-from-file' )">Create a Geomark from File</a></li>
     </ul>
 
     <div v-if="geomarks.length != 0" id="geomarks-container">

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -18,6 +18,7 @@ include.module( 'tool-geomark', [
         template: inc[ 'tool-geomark.panel-geomark-html' ],
         props: [ 
             'geomarks', 
+            'enableCreateFromFile', 
             'showAlert', 
             'showPrompt', 
             'alertBody',
@@ -33,6 +34,7 @@ include.module( 'tool-geomark', [
             SMK.TYPE.ToolPanel.call( this, 'geomark-panel' );
 
             this.defineProp( 'geomarkService' );
+            this.defineProp( 'enableCreateFromFile' );
             this.defineProp( 'geomarks' );
             this.defineProp( 'showAlert');
             this.defineProp( 'showPrompt');


### PR DESCRIPTION
This adds support for a "enableCreateFromFile" configuration property. When set true, the "Create geomark from a file" link is shown; otherwise, it is hidden.

Based on customer feedback, the existing link is not of high value, but we want app authors to be able to include it if they feel it is helpful to their users.

Example configuration for the Geomark tool:

        {
            "title": "Geomark",
            "geomarkService": {
                "url": "https://apps.gov.bc.ca/pub/geomark"
            },
            "enableCreateFromFile": true,
            "type": "geomark",
            "enabled": true,
        },
