### PR TITLE
Close-alert error fixed

### DIFF
--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -253,7 +253,9 @@ include.module( 'tool-geomark', [
                 },
                 'close-alert': function() {
                     self.showAlert = false;
-                    self.handleAlert();
+                    if (self.handleAlert) {
+                        self.handleAlert();
+                    }
                     self.handleAlert = undefined;
                 },
                 'cancel-prompt': function() {


### PR DESCRIPTION
This addresses the error (seen in console logs) given when attempting to call the "handleAlert" function when it is undefined. This adds a check that the function is defined before calling it.

To reproduce the error, draw a geomark shape, save the drawing, and click 'OK' on the alert that appears afterwards.