### PR TITLE
Loaded geomarks cannot be edited or removed

### DIFF
--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -116,12 +116,16 @@ include.module( 'tool-geomark', [
                 }
             } 
 
-            this.setCurrentDrawingLayer = function(e) {
-                var eventLayer = e.layer;
-                eventLayer.pm.setOptions( {
+            this.freezeLayer = function(layer) {
+                layer.pm.setOptions( {
                     'allowEditing': false,
                     'allowRemoval': false
                 } );
+            }
+
+            this.setCurrentDrawingLayer = function(e) {
+                var eventLayer = e.layer;
+                self.freezeLayer(eventLayer);
                 currentDrawingLayer.addLayer(eventLayer);
             }
 
@@ -210,7 +214,9 @@ include.module( 'tool-geomark', [
                             style: function (feature) {
                                 return {color: CUSTOM_COLOUR};
                             }
-                        }).addTo(smk.$viewer.map);
+                        });
+                        self.freezeLayer(geometryLayer);
+                        geometryLayer.addTo(smk.$viewer.map);
                         self.geomarks.push(self.toGeomark(geomarkFeature, geometryLayer));
                     },
                     error: function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
This addresses an oversight where new geomarks were made immutable but loaded geomarks were not.