### PR TITLE
jshint uses esversion 6

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -45,6 +45,7 @@ module.exports = function( grunt ) {
                 // latedef: true,
                 // curly: true,
                 // eqeqeq: true,
+                esversion:  6,
                 bitwise:    true,
                 strict:     true,
                 undef:      true,

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -74,7 +74,7 @@ include.module( 'tool-geomark', [
                 return;
             }
 
-            var CUSTOM_COLOUR = '#ee0077';
+            const CUSTOM_COLOUR = '#ee0077';
 
             // Used to specify action(s) to be executed when an alert is confirmed
             this.handleAlert = undefined;


### PR DESCRIPTION
This allows us to use newer Javascript language functionality and avoid jshint warnings.