### PR TITLE
Override Identify click handling

### DIFF
--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -202,6 +202,14 @@ include.module( 'tool-geomark', [
                 }
             } )
 
+            // Override default handling in Identify tool
+            smk.$viewer.handlePick( 1, function ( location ) {
+                if ( !self.active ) {
+                    return;
+                }
+                return true;
+            } )
+
             this.updateAndShowAlert = function(alertBodyArg) {
                 self.alertBody = alertBodyArg;
                 self.showAlert = true;

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -207,7 +207,7 @@ include.module( 'tool-geomark', [
                 if ( !self.active ) {
                     return;
                 }
-                return true;
+                return Promise.resolve(true);
             } )
 
             this.updateAndShowAlert = function(alertBodyArg) {

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -203,7 +203,7 @@ include.module( 'tool-geomark', [
             } )
 
             // Override default handling in Identify tool
-            smk.$viewer.handlePick( 1, function ( location ) {
+            smk.$viewer.handlePick( 4, function ( location ) {
                 if ( !self.active ) {
                     return;
                 }


### PR DESCRIPTION
This updates the Geomark tool to override the default click handling of the Identify tool, but only when the Geomark panel is active.