### PR TITLE
Geomark checkboxes reflect visibility

### DIFF
--- a/src/smk/tool/geomark/panel-geomark.html
+++ b/src/smk/tool/geomark/panel-geomark.html
@@ -23,7 +23,7 @@
             <h3>Loaded Geomarks</h3>
             <ul class="smk-no-list-style">
                 <li class="smk-truncate-with-ellipsis" v-for="geomark in geomarks">
-                    <input type="checkbox" checked v-bind:id="geomark.id" v-on:click="$$emit( 'toggle-geomark', { id: geomark.id } )">
+                    <input type="checkbox" v-bind:checked="geomark.isVisible" v-bind:id="geomark.id" v-on:click="$$emit( 'toggle-geomark', { id: geomark.id } )">
                     <a v-bind:href="geomark.url" target="_blank">{{ geomark.id}}</a>
                 </li>
             </ul>

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -219,7 +219,8 @@ include.module( 'tool-geomark', [
                 return {
                     id: geomarkInfo.id || geomarkInfo.properties.id,
                     url: geomarkInfo.url || geomarkInfo.properties.url,
-                    drawingLayer: drawingLayer
+                    drawingLayer: drawingLayer,
+                    isVisible: true
                 };
             }
 
@@ -320,6 +321,7 @@ include.module( 'tool-geomark', [
                     } else {
                         smk.$viewer.map.addLayer(geomark.drawingLayer);
                     }
+                    geomark.isVisible = !geomark.isVisible;
                 },
                 'close-alert': function() {
                     self.showAlert = false;


### PR DESCRIPTION
When leaving and re-entering the Geomark panel, loaded geomarks are checked by default. This adds visibility state to members of the geomarks property, which is used to determine whether each geomark's checkbox is checked.

This addresses issue https://github.com/bcgov/smk/issues/153.