### PR TITLE
Removing Geomark "Load File" functionality

### DIFF
--- a/docs/configuration/tools/geomark.md
+++ b/docs/configuration/tools/geomark.md
@@ -18,7 +18,6 @@ This is default configuration for the Geomark tool (click on a property name for
     <a href="#geomark-service-property">"geomarkService"</a>: {
         <a href="#url-sub-property">"url"</a>:            "https://apps.gov.bc.ca/pub/geomark"
     },
-    <a href="#enable-create-from-file-property">"enableCreateFromFile"</a>: false,
     <a href="#enabled-property">"enabled"</a>:        false,
     <a href="#icon-property"     >"icon"</a>:           <a href="https://material.io/tools/icons/?icon=build" target="material">"build"</a>,
     <a href="#order-property"    >"order"</a>:          1,
@@ -43,8 +42,3 @@ Contains properties of the geomark web service.
 `"geomarkService"`: `{ "url": String }`
 
 The URL of the geomark web service used.
-
-## Enable Create From File Property
-`"enableCreateFromFile"`: `Boolean`
-
-When true, the panel will contain an option to navigate to the Geomark service where a file can be uploaded to create a new geomark. The geomark can then be added to the map by loading it.

--- a/src/smk/tool/geomark/panel-geomark.html
+++ b/src/smk/tool/geomark/panel-geomark.html
@@ -13,10 +13,9 @@
         <p>Use geomarks to create and share areas of interest. Create a geomark by drawing a shape on the map and saving it, or load an existing geomark by its link.</p>    
     
         <div>
-            <button v-on:click="$$emit( 'create-geomark-from-drawing' )" :disabled="canSave === false">Save</button>
+            <button v-on:click="$$emit( 'create-geomark' )" :disabled="canSave === false">Save</button>
             <button v-on:click="$$emit( 'clear-drawing' )" :disabled="canClear === false">Clear</button>
             <button v-on:click="$$emit( 'load-geomark' )">Load URL</button>
-            <button v-if="enableCreateFromFile === true" v-on:click="$$emit( 'create-geomark-from-file' )">Load File</button>
         </div>
     
         <div v-if="geomarks.length !== 0" id="geomarks-container">

--- a/src/smk/tool/geomark/tool-geomark.js
+++ b/src/smk/tool/geomark/tool-geomark.js
@@ -18,7 +18,6 @@ include.module( 'tool-geomark', [
         template: inc[ 'tool-geomark.panel-geomark-html' ],
         props: [ 
             'geomarks', 
-            'enableCreateFromFile', 
             'canSave',
             'canClear',
             'showAlert', 
@@ -37,7 +36,6 @@ include.module( 'tool-geomark', [
             SMK.TYPE.ToolPanel.call( this, 'geomark-panel' );
 
             this.defineProp( 'geomarkService' );
-            this.defineProp( 'enableCreateFromFile' );
             this.defineProp( 'geomarks' );
             this.defineProp( 'canSave' );
             this.defineProp( 'canClear' );
@@ -75,9 +73,6 @@ include.module( 'tool-geomark', [
             }
 
             const CUSTOM_COLOUR = '#ee0077';
-
-            // Used to specify action(s) to be executed when an alert is confirmed
-            this.handleAlert = undefined;
 
             this.createCurrentLayerGroup = function() {
                 var layerGroup = new L.FeatureGroup();
@@ -264,10 +259,6 @@ include.module( 'tool-geomark', [
                 });
             }
 
-            this.openGeomarkFileWindow = function() {
-                window.open(self.geomarkService.url + '/geomarks#file');
-            }
-
             var client = new window.GeomarkClient(self.geomarkService.url);
 
             smk.on( this.id, {
@@ -278,7 +269,7 @@ include.module( 'tool-geomark', [
                     self.canSave = false;
                     self.canClear = false;
                 },
-                'create-geomark-from-drawing': function () {
+                'create-geomark': function () {
                     if (currentLayerGroup.getLayers().length == 0) {
                         self.showStatusMessage('No drawings were found. Draw one or more polygons before creating a geomark.', 'warning', 5000);
                         return;
@@ -303,10 +294,6 @@ include.module( 'tool-geomark', [
                         }
                     });
                 },
-                'create-geomark-from-file': function () {
-                    self.handleAlert = self.openGeomarkFileWindow;
-                    self.updateAndShowAlert('Upload your file using the form in the new window. Once you have a Geomark URL, add it to the map using "Load URL".');
-                },
                 'load-geomark': function() {
                     self.promptBody = 'Enter the URL of a geomark to load:';
                     self.showPrompt = true;
@@ -325,10 +312,6 @@ include.module( 'tool-geomark', [
                 },
                 'close-alert': function() {
                     self.showAlert = false;
-                    if (self.handleAlert) {
-                        self.handleAlert();
-                    }
-                    self.handleAlert = undefined;
                 },
                 'cancel-prompt': function() {
                     self.showPrompt = false;


### PR DESCRIPTION
This removes the "Load File" button and related functionality from the Geomark tool. The link to create a geomark from a file must be updated here whenever the link changes, and we have not heard of customers still wanting this functionality (which was carried over from DMF2), so we are removing it.