### PR TITLE
Add geomark tool to config doc index

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -35,6 +35,7 @@ The `"layers"` and `"tools"` collections can contain a variety of possible objec
         { "type": <a href="tools/bespoke"        >"bespoke"</a>       },
         { "type": <a href="tools/coordinate"     >"coordinate"</a>    },
         { "type": <a href="tools/directions"     >"directions"</a>    },
+        { "type": <a href="tools/geomark"        >"geomark"</a>       },
         { "type": <a href="tools/identify"       >"identify"</a>      },
         { "type": <a href="tools/layers"         >"layers"</a>        },
         { "type": <a href="tools/legend"         >"legend"</a>        },


### PR DESCRIPTION
While reviewing documentation for the Bespoke tool, I noticed I'd never added a link to the Geomark tool docs in the configuration docs index page.
