### PR TITLE
Removing code that incorrectly references other tools

### DIFF
--- a/src/smk/tool/identify/tool-identify-feature.js
+++ b/src/smk/tool/identify/tool-identify-feature.js
@@ -28,7 +28,6 @@ include.module( 'tool-identify.tool-identify-feature-js', [
                 }
             } )
 
-            // smk.$tool.identify.startedIdentify( function () {
             smk.getToolById( 'IdentifyListTool' ).startedIdentify( function () {
                 smk.getToolById( self.parentId ).active = true
             } )

--- a/src/smk/tool/location/panel-location.html
+++ b/src/smk/tool/location/panel-location.html
@@ -5,12 +5,6 @@
         <slot></slot>
     </template>
 
-    <template slot="commands">
-        <span class="smk-command" v-if="tool.identify" v-on:click="$$emit( 'identify' )">Identify features</span>
-        <span class="smk-command" v-if="tool.measure" v-on:click="$$emit( 'measure' )">Start measurement</span>
-        <span class="smk-command" v-if="tool.directions" v-on:click="$$emit( 'directions' )">Directions to here</span>
-    </template>    
-
     <div class="smk-address">
         <div class="smk-street">
             <span class="smk-civic-number">{{ site.civicNumber }}</span>

--- a/src/smk/tool/location/tool-location.js
+++ b/src/smk/tool/location/tool-location.js
@@ -31,20 +31,20 @@ include.module( 'tool-location', [
             this.geocoder = new SMK.TYPE.Geocoder( this.geocoderService )
 
             this.setIdentifyHandler = function ( handler ) {
-                if ( !smk.$tool.identify ) return
+                // if ( !smk.$tool.identify ) return
 
-                self.tool.identify = !!handler
+                // self.tool.identify = !!handler
 
-                self.identifyHandler = handler || function () {}
+                // self.identifyHandler = handler || function () {}
             }
             self.identifyHandler = function () {}
 
             this.setDirectionsHandler = function ( handler ) {
-                if ( !smk.$tool.directions ) return
+                // if ( !smk.$tool.directions ) return
 
-                self.tool.directions = !!handler
+                // self.tool.directions = !!handler
 
-                self.directionsHandler = handler || function () {}
+                // self.directionsHandler = handler || function () {}
             }
             self.directionsHandler = function () {}
 
@@ -81,15 +81,15 @@ include.module( 'tool-location', [
 
                         self.setDirectionsHandler( function () {
                             self.reset()
-                            smk.$tool.directions.active = true
+                            // smk.$tool.directions.active = true
 
-                            smk.$tool.directions.activating
-                                .then( function () {
-                                    return smk.$tool.directions.startAtCurrentLocation()
-                                } )
-                                .then( function () {
-                                    return smk.$tool.directions.addWaypoint( site )
-                                } )
+                            // smk.$tool.directions.activating
+                            //     .then( function () {
+                            //         return smk.$tool.directions.startAtCurrentLocation()
+                            //     } )
+                            //     .then( function () {
+                            //         return smk.$tool.directions.addWaypoint( site )
+                            //     } )
                         } )
 
                         return true

--- a/src/smk/tool/location/tool-location.js
+++ b/src/smk/tool/location/tool-location.js
@@ -30,67 +30,14 @@ include.module( 'tool-location', [
 
             this.geocoder = new SMK.TYPE.Geocoder( this.geocoderService )
 
-            this.setIdentifyHandler = function ( handler ) {
-                // if ( !smk.$tool.identify ) return
-
-                // self.tool.identify = !!handler
-
-                // self.identifyHandler = handler || function () {}
-            }
-            self.identifyHandler = function () {}
-
-            this.setDirectionsHandler = function ( handler ) {
-                // if ( !smk.$tool.directions ) return
-
-                // self.tool.directions = !!handler
-
-                // self.directionsHandler = handler || function () {}
-            }
-            self.directionsHandler = function () {}
-
-            // if ( smk.$tool.measure )
-            //     this.tool.measure = true
-
-            smk.on( this.id, {
-                'identify': function () {
-                    self.identifyHandler()
-                },
-
-                'measure': function () {
-                },
-
-                'directions': function () {
-                    self.directionsHandler()
-                }
-            } )
-
             smk.$viewer.handlePick( 1, function ( location ) {
                 self.active = true
                 self.site = location.map
                 self.pickLocation( location )
 
-                self.setDirectionsHandler()
-                self.setIdentifyHandler( function () {
-                    self.reset()
-                    smk.$viewer.identifyFeatures( location )
-                } )
-
                 return self.geocoder.fetchNearestSite( location.map )
                     .then( function ( site ) {
                         self.site = site
-
-                        self.setDirectionsHandler( function () {
-                            self.reset()
-                            // smk.$tool.directions.active = true
-
-                            // smk.$tool.directions.activating
-                            //     .then( function () {
-                            //         return smk.$tool.directions.startAtCurrentLocation()
-                            //     } )
-                            //     .then( function () {
-                            //         return smk.$tool.directions.addWaypoint( site )
-                            //     } )
-                        } )
 
                         return true
                     } )
@@ -104,8 +51,6 @@ include.module( 'tool-location', [
             this.reset = function () {
                 this.site = {}
                 this.active = false
-                self.setDirectionsHandler()
-                self.setIdentifyHandler()
             }
 
             smk.$viewer.changedView( function () {

--- a/src/smk/tool/search/panel-search-location.html
+++ b/src/smk/tool/search/panel-search-location.html
@@ -5,6 +5,7 @@
         <slot></slot>
     </template>
 
+    <!--
     <template slot="commands">
         <command-button class="smk-identify"
             v-if="command.identify && tool.identify"
@@ -21,6 +22,7 @@
             v-on:click="$$emit( 'directions' )"
         >Directions to here</command-button>
     </template>
+    -->
 
     <component class="smk-address"
         v-bind:is="locationComponent"

--- a/src/smk/tool/search/panel-search-location.html
+++ b/src/smk/tool/search/panel-search-location.html
@@ -5,25 +5,6 @@
         <slot></slot>
     </template>
 
-    <!--
-    <template slot="commands">
-        <command-button class="smk-identify"
-            v-if="command.identify && tool.identify"
-            v-on:click="$$emit( 'identify' )"
-        >Identify features</command-button>
-
-        <command-button class="smk-measure"
-            v-if="command.measure && tool.measure"
-            v-on:click="$$emit( 'measure' )"
-        >Start measurement</command-button>
-
-        <command-button class="smk-directions"
-            v-if="command.directions && tool.directions"
-            v-on:click="$$emit( 'directions' )"
-        >Directions to here</command-button>
-    </template>
-    -->
-
     <component class="smk-address"
         v-bind:is="locationComponent"
     ></component>

--- a/src/smk/tool/search/tool-search-location.js
+++ b/src/smk/tool/search/tool-search-location.js
@@ -42,27 +42,6 @@ include.module( 'tool-search.tool-search-location-js', [
                 }
             } )
 
-            // smk.on( this.id, {
-            //     'directions': function () {
-            //         smk.$tool.directions.active = true
-
-            //         smk.$tool.directions.activating
-            //             .then( function () {
-            //                 return smk.$tool.directions.startAtCurrentLocation()
-            //             } )
-            //             .then( function () {
-            //                 return SMK.UTIL.findNearestSite( { latitude: self.feature.geometry.coordinates[ 1 ], longitude: self.feature.geometry.coordinates[ 0 ] } )
-            //                     .then( function ( site ) {
-            //                         return smk.$tool.directions.addWaypoint( site )
-            //                     } )
-            //                     .catch( function ( err ) {
-            //                         console.warn( err )
-            //                         return smk.$tool.directions.addWaypoint()
-            //                     } )
-            //             } )
-            //     }
-            // } )
-
             smk.$viewer.searched.pickedFeature( function ( ev ) {
                 self.locationComponent = {
                     name: 'location',

--- a/src/smk/tool/search/tool-search-location.js
+++ b/src/smk/tool/search/tool-search-location.js
@@ -42,26 +42,26 @@ include.module( 'tool-search.tool-search-location-js', [
                 }
             } )
 
-            smk.on( this.id, {
-                'directions': function () {
-                    smk.$tool.directions.active = true
+            // smk.on( this.id, {
+            //     'directions': function () {
+            //         smk.$tool.directions.active = true
 
-                    smk.$tool.directions.activating
-                        .then( function () {
-                            return smk.$tool.directions.startAtCurrentLocation()
-                        } )
-                        .then( function () {
-                            return SMK.UTIL.findNearestSite( { latitude: self.feature.geometry.coordinates[ 1 ], longitude: self.feature.geometry.coordinates[ 0 ] } )
-                                .then( function ( site ) {
-                                    return smk.$tool.directions.addWaypoint( site )
-                                } )
-                                .catch( function ( err ) {
-                                    console.warn( err )
-                                    return smk.$tool.directions.addWaypoint()
-                                } )
-                        } )
-                }
-            } )
+            //         smk.$tool.directions.activating
+            //             .then( function () {
+            //                 return smk.$tool.directions.startAtCurrentLocation()
+            //             } )
+            //             .then( function () {
+            //                 return SMK.UTIL.findNearestSite( { latitude: self.feature.geometry.coordinates[ 1 ], longitude: self.feature.geometry.coordinates[ 0 ] } )
+            //                     .then( function ( site ) {
+            //                         return smk.$tool.directions.addWaypoint( site )
+            //                     } )
+            //                     .catch( function ( err ) {
+            //                         console.warn( err )
+            //                         return smk.$tool.directions.addWaypoint()
+            //                     } )
+            //             } )
+            //     }
+            // } )
 
             smk.$viewer.searched.pickedFeature( function ( ev ) {
                 self.locationComponent = {


### PR DESCRIPTION
This comments out code that references other tools by using invalid tool names. Tool names were once all lowercase but are now camel case, but some references to the old tool names remain. This comments out such code because it is currently not functional. This may help prevent bugs, and by preserving the code we keep its intent should we want to bring back functionality later.

This also comments out nonfunctional buttons in the Search tool. The Identify and Measure buttons do not have implementation code, and the code called by the Directions button results in a console error because of an undefined value.