### PR TITLE
ESRI layer docs mention drawingInfo and showLabels

### DIFF
--- a/docs/configuration/layers/esri-dynamic.md
+++ b/docs/configuration/layers/esri-dynamic.md
@@ -61,9 +61,11 @@ The URL for the DataBC Layer Catalog.
 ## DynamicLayers Property
 `"dynamicLayers": Array`
 
-A listing of dynamic layer configurations.
-This will typically only contain one dynamic feature, which can be derived from the MPCM Layer Catalog.
+A listing of dynamic layer configurations in JSON format. This will typically only contain one dynamic feature. This configuration comes from the MPCM Layer Catalog.
 
+### DrawingInfo Property
+`"drawingInfo": Object`
 
+Each `dynamicLayers` property includes a `drawingInfo` property. This is an object in JSON format that is included in SMK requests for layer tiles. `drawingInfo` can be manually edited to configure aspects of layer display. For more information, see <a href="https://developers.arcgis.com/web-map-specification/objects/drawingInfo">`drawingInfo` documentation</a>.
 
-
+If a value exists for `drawingInfo`'s `labelingInfo` property in an ESRI dynamic layer, SMK-CLI's panel for editing the layer will include a "Show labels" check box. This toggles the value of the `showLabels` property of `drawingInfo`. 

--- a/docs/configuration/layers/esri-dynamic.md
+++ b/docs/configuration/layers/esri-dynamic.md
@@ -61,11 +61,9 @@ The URL for the DataBC Layer Catalog.
 ## DynamicLayers Property
 `"dynamicLayers": Array`
 
-A listing of dynamic layer configurations in JSON format. This will typically only contain one dynamic feature. This configuration comes from the MPCM Layer Catalog.
+A listing of dynamic layer configurations. This will typically contain configuration for a single layer. The default configuration comes from the MPCM Layer Catalog.
 
 ### DrawingInfo Property
 `"drawingInfo": Object`
 
-Each `dynamicLayers` property includes a `drawingInfo` property. This is an object in JSON format that is included in SMK requests for layer tiles. `drawingInfo` can be manually edited to configure aspects of layer display. For more information, see <a href="https://developers.arcgis.com/web-map-specification/objects/drawingInfo">`drawingInfo` documentation</a>.
-
-If a value exists for `drawingInfo`'s `labelingInfo` property in an ESRI dynamic layer, SMK-CLI's panel for editing the layer will include a "Show labels" check box. This toggles the value of the `showLabels` property of `drawingInfo`. 
+Each `dynamicLayers` property includes a `drawingInfo` property which defines the appearance of the layer on the map. `drawingInfo` can be manually edited to configure aspects of layer display. For more information, see <a href="https://developers.arcgis.com/web-map-specification/objects/drawingInfo">`drawingInfo` documentation</a>.


### PR DESCRIPTION
This updates documentation for ESRI dynamic layers by adding reference for the 'drawingInfo' property. It also mentions that SMK-CLI can toggle the display of labels via the 'showLabels' property.