### PR TITLE
Version incremented, redundant font-family style removed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/smk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/smk",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "APSL-2.0",
       "devDependencies": {
         "browser-sync": "~2.27.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.9",
+  "version": "1.0.10",
   "name": "@bcgov/smk",
   "title": "Simple Map Kit",
   "description": "A simple way to add a map your application.",

--- a/src/theme/_base/map-frame.css
+++ b/src/theme/_base/map-frame.css
@@ -1,5 +1,4 @@
 .smk-map-frame {
-    font-family: Helvetica,Arial,sans-serif;
     position: relative;
 }
 


### PR DESCRIPTION
This increments the version to synchronize with related changes in SMK-CLI where the BC Sans font will be added and set in the main style sheet for created SMK apps. SMK-CLI changes will depend on this incremented version.

This also removes the font-family style in the map frame styling, which has the same value as the font-family style in style.css (added to new applications by 'smk create'). We remove it because it is redundant and because it overrides the font-family change to BC Sans we want to make in smk-cli to style.css.