### PR TITLE
Add default minZoom, maxZoom values to viewer config

### DIFF
--- a/docs/configuration/viewer.md
+++ b/docs/configuration/viewer.md
@@ -17,6 +17,8 @@ Click on a property name for more information:
     <a href="#basemap-property"                 >"baseMap"</a>:     "Topographic",
     <a href="#esriapikey-property"              >"esriApiKey"</a>:  null,
     <a href="#activeTool-property"              >"activeTool"</a>:  null,
+    <a href="#minZoom-property"                 >"minZoom"</a>:  null,
+    <a href="#maxZoom-property"                 >"maxZoom"</a>:  null,
     <a href="#location-property"                >"location"</a>: {
         <a href="#extent-sub-property"          >"extent"</a>:  [ -139.1782, 47.6039, -110.3533, 60.5939 ],
         <a href="#center-sub-property"          >"center"</a>:  [ -124.76575, 54.0989 ],
@@ -105,6 +107,15 @@ If you are not using an Esri basemap, this value can be empty. If you use an emp
 
 If this property is set to the id of a tool, then this tool will be active when the map is finished initialization.
 
+## MinZoom Property
+`"minZoom": Number`
+
+The map's minimum zoom level. Set a value to override the default value of 1.
+
+## MaxZoom Property
+`"maxZoom": String`
+
+The map's maximum zoom level. Set a value to override the default value of 22.
 
 ## Location Property
 `"location": String`

--- a/src/smk/viewer-leaflet/viewer-leaflet.js
+++ b/src/smk/viewer-leaflet/viewer-leaflet.js
@@ -28,7 +28,8 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
             boxZoom:            false,
             doubleClickZoom:    false,
             zoomSnap:           0,
-            minZoom:            smk.viewer.minZoom
+            minZoom:            smk.viewer.minZoom || 1,
+            maxZoom:            smk.viewer.maxZoom || 22
         } )
 
         // Create a panel for basemaps with a low z-index to ensure they draw below layers


### PR DESCRIPTION
New ESRI basemaps do not have a maxZoom value, and this causes an error to be thrown from the marker-cluster library. This change adds a maxZoom property to map options in viewer-leaflet.js, adds default values for minZoom and maxZoom, and updates viewer configuration docs to add the minZoom and maxZoom properties.