### PR TITLE
Remove ver parameter from geocoder URLs

### DIFF
--- a/src/smk/query/query-place.js
+++ b/src/smk/query/query-place.js
@@ -25,7 +25,6 @@ include.module( 'query.query-place-js', [ 'query.query-js' ], function () {
         var self = this
 
         var query = {
-            ver:            1.2,
             maxResults:     20,
             outputSRS:      4326,
             addressString:  param.param1.value,

--- a/src/smk/tool/search/tool-search-list.js
+++ b/src/smk/tool/search/tool-search-list.js
@@ -14,7 +14,6 @@ include.module( 'tool-search.tool-search-list-js', [
             request.abort()
 
         var query = {
-            ver:            1.2,
             maxResults:     10,
             outputSRS:      4326,
             addressString:  text,


### PR DESCRIPTION
This URL parameter is no longer used by the Geocoder API.