### PR TITLE
Fix identify on Esri feature layers

### DIFF
--- a/src/smk/layer/layer-esri-feature.js
+++ b/src/smk/layer/layer-esri-feature.js
@@ -69,6 +69,7 @@ include.module( 'layer.layer-esri-feature-js', [ 'layer.layer-js', 'terraformer'
 
             return data.features.map( function ( r, i ) {
                 var f = {}
+                f.type = 'Feature';
 
                 if ( r.displayFieldName )
                     f.title = r.attributes[ r.displayFieldName ]


### PR DESCRIPTION
If your SMK app contains an Esri feature layer and you perform an identify, you will see an unhandled error logged to the developer console ("Unknown Geometry Type"). This happens because features returned from `getFeaturesInArea()` in `layer-esri-feature.js` are missing the following attribute: `type: 'Feature'`.

To observe the old behavior:
1. Checkout the smk-clean-bc repo https://github.com/bcgov/smk-clean-bc
2. npm install
3. npm run view
4. Click on a dot on the map and check your browser's dev console
