### PR TITLE
Expose geometry in Identify features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/smk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/smk",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "APSL-2.0",
       "devDependencies": {
         "browser-sync": "~2.27.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.1.3",
   "name": "@bcgov/smk",
   "title": "Simple Map Kit",
   "description": "A simple way to add a map your application.",

--- a/src/smk/tool/identify/tool-identify-feature.js
+++ b/src/smk/tool/identify/tool-identify-feature.js
@@ -86,6 +86,7 @@ include.module( 'tool-identify.tool-identify-feature-js', [
                 self.feature = {
                     id:         ev.feature.id,
                     title:      ev.feature.title,
+                    geometry:   ev.feature.geometry,
                     properties: Object.assign( {}, ev.feature.properties )
                 }
 


### PR DESCRIPTION
This exposes the 'geometry' attribute of features in the Identify tool. SMK configuration for a layer can then use the geometry for custom layer attribute values.

The SMK version is also incremented so that SMK apps needing this functionality can specify the new version.