### PR TITLE
Show route stats in directions panel

### DIFF
--- a/src/smk/tool/directions/panel-directions.html
+++ b/src/smk/tool/directions/panel-directions.html
@@ -47,6 +47,8 @@
         ></command-button>
     </template>
 
+    <div v-if="hasRoute" class="smk-route-stats">{{ routeStats }}</div>
+
     <draggable class="smk-waypoints"
         v-bind:list="waypoints"
         v-bind:options="{ handle: '.smk-handle', disabled: optimal }"

--- a/src/smk/tool/directions/tool-directions-waypoints.js
+++ b/src/smk/tool/directions/tool-directions-waypoints.js
@@ -24,7 +24,7 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
     Vue.component( 'directions-panel', {
         extends: SMK.COMPONENT.ToolPanelBase,
         template: inc[ 'tool-directions.panel-directions-html' ],
-        props: [ 'waypoints', 'hasRoute', 'optimal', 'geocoderService' ],
+        props: [ 'waypoints', 'hasRoute', 'routeStats', 'optimal', 'geocoderService' ],
     } )
     // _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     //
@@ -35,6 +35,7 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
 
             this.defineProp( 'waypoints' )
             this.defineProp( 'hasRoute' )
+            this.defineProp( 'routeStats' )
             this.defineProp( 'optimal' )
             this.defineProp( 'geocoderService' )
             this.defineProp( 'routePlannerService' )
@@ -310,7 +311,9 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
 
                         self.displayWaypoints()
 
-                        self.showStatusMessage( 'Route travels ' + data.distance + ' km in ' + data.timeText, 'summary' )
+                        self.routeStats = data.distance + ' km in ' + data.timeText;
+
+                        self.showStatusMessage( 'Route travels ' + self.routeStats, 'summary' )
 
                         self.hasRoute = true
 

--- a/src/smk/tool/directions/tool-directions.css
+++ b/src/smk/tool/directions/tool-directions.css
@@ -44,3 +44,10 @@
     margin: 4px;
     width: calc( 100% - 46px );
 }
+
+.smk-directions-panel .smk-route-stats {
+    font-size: 12px;
+    font-style: italic;
+    margin-left: 5px;
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
The distance and time of a route appear briefly after a route is calculated. A customer has requested that these statistics also be persisted on the screen.