### PR TITLE
Route stats reformatted based on viewer feedback

### DIFF
--- a/src/smk/tool/directions/tool-directions-waypoints.js
+++ b/src/smk/tool/directions/tool-directions-waypoints.js
@@ -311,7 +311,8 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
 
                         self.displayWaypoints()
 
-                        self.routeStats = data.distance + ' km in ' + data.timeText;
+                        const distanceRounded = Number.isNaN(data.distance) ? data.distance : data.distance.toFixed(1);
+                        self.routeStats = `${distanceRounded} ${data.distanceUnit}  (${data.timeText})`;
 
                         self.showStatusMessage( 'Route travels ' + self.routeStats, 'summary' )
 


### PR DESCRIPTION
This rounds the route distance from 3 decimal places to 1 and moves the time into parentheses. This also uses the distance unit from provided data instead of hard-coding kilometers.