### PR TITLE
Directions waypoints method returns data

### DIFF
--- a/src/smk/tool/directions/tool-directions-waypoints.js
+++ b/src/smk/tool/directions/tool-directions-waypoints.js
@@ -79,7 +79,7 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
                 self.showStatusMessage( 'Finding current location...', 'progress', null )
                 self.busy = true
 
-                smk.$viewer.getCurrentLocation().finally( function () {
+                return smk.$viewer.getCurrentLocation().finally( function () {
                     self.busy = false
                     self.showStatusMessage()
                 } )


### PR DESCRIPTION
This fixes an error where the waypoints method getCurrentLocation() did not return a value and code calling the method attempted to call a method on the undefined return value.
