### PR TITLE
Can hide Esri feature layer legend

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
@@ -36,12 +36,14 @@ include.module( 'layer-leaflet.layer-esri-feature-leaflet-js', [ 'layer.layer-es
                 // cfg.drawingInfo.renderer.symbol.url = this.resolveUrl( cfg.drawingInfo.renderer.symbol.url )
                 cfg.drawingInfo.renderer.symbol.url = ( new URL( cfg.drawingInfo.renderer.symbol.url, document.location ) ).toString()
         }
-        
+
         var layer = L.esri.featureLayer( cfg )
         
         if ( layers[ 0 ].legendCacheResolve ) {
+            const hideLegend = layers[0].config.hideLegend ? layers[0].config.hideLegend : "";
             layer.legend( function ( err, leg ) {
-                layers[ 0 ].legendCacheResolve( err ? null : leg.layers[ 0 ].legend )
+                layers[0].legendCacheResolve(err ? null : 
+                    leg.layers[0].legend.filter(lg => lg.values.every(v => !hideLegend.includes(v))));
                 layers[ 0 ].legendCacheResolve = null
             } )
         }

--- a/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
@@ -40,10 +40,13 @@ include.module( 'layer-leaflet.layer-esri-feature-leaflet-js', [ 'layer.layer-es
         var layer = L.esri.featureLayer( cfg )
         
         if ( layers[ 0 ].legendCacheResolve ) {
-            const hideLegend = layers[0].config.hideLegend ? layers[0].config.hideLegend : "";
+            const hideLegends = layers[0].config.hideLegends ? layers[0].config.hideLegends : [];
             layer.legend( function ( err, leg ) {
                 layers[0].legendCacheResolve(err ? null : 
-                    leg.layers[0].legend.filter(lg => lg.values.every(v => !hideLegend.includes(v))));
+                    leg.layers[0].legend.filter(lg => 
+                        lg.values.every(v => 
+                            hideLegends.every(hl => 
+                                v.toLowerCase() !== hl.toLowerCase()))));
                 layers[ 0 ].legendCacheResolve = null
             } )
         }


### PR DESCRIPTION
Esri feature layers can have multiple legends to reflect differing symbology that is based on differing values for a field. When the "where" option is used to omit features based on such a field value, the legend for the omitted value still appears.

This change introduces a 'hideLegend' parameter to Esri feature layer configuration. When the names of one or more legend values are used, those legends are omitted from viewer display context and do not display in UI legends.