### PR TITLE
Improve ordering of layers

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-esri-dynamic-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-dynamic-leaflet.js
@@ -11,6 +11,8 @@ include.module( 'layer-leaflet.layer-esri-dynamic-leaflet-js', [ 'layer.layer-es
     // _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     //
     SMK.TYPE.Layer[ 'esri-dynamic' ][ 'leaflet' ].create = function ( layers, zIndex ) {
+        var self = this;
+
         if ( layers.length != 1 ) throw new Error( 'only 1 config allowed' )
 
         var serviceUrl  = layers[ 0 ].config.serviceUrl
@@ -27,27 +29,30 @@ include.module( 'layer-leaflet.layer-esri-dynamic-leaflet-js', [ 'layer.layer-es
         if ( layers[ 0 ].config.maxScale )
             maxZoom = this.getZoomBracketForScale( layers[ 0 ].config.maxScale )[ 1 ]
 
-        var layer
+        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
+        const thisLayerPane = self.map.createPane(String(layers[0].config.id), layerPane);
+        thisLayerPane.style.zIndex = zIndex;
+    
+        var layer;
         if ( dynamicLayers ) {
             layer = L.esri.dynamicMapLayer( {
                 url:            serviceUrl,
                 opacity:        opacity,
                 dynamicLayers:  dynamicLayers,
                 maxZoom:        maxZoom,
-                minZoom:        minZoom
+                minZoom:        minZoom,
+                pane:           layerPane
             });
         }
         else {
             layer = L.esri.featureLayer( {
                 url:            serviceUrl,
-                where:          layers[ 0 ].config.where
-            } )
+                where:          layers[ 0 ].config.where,
+                pane:           layerPane
+        } )
         }
         
         layer.on( 'load', function ( ev ) {
-            if ( layer._currentImage )
-                layer._currentImage.setZIndex( zIndex )
-
             layers[ 0 ].loading = false
         } )
 

--- a/src/smk/viewer-leaflet/layer/layer-esri-dynamic-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-dynamic-leaflet.js
@@ -29,9 +29,9 @@ include.module( 'layer-leaflet.layer-esri-dynamic-leaflet-js', [ 'layer.layer-es
         if ( layers[ 0 ].config.maxScale )
             maxZoom = this.getZoomBracketForScale( layers[ 0 ].config.maxScale )[ 1 ]
 
-        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
-        const thisLayerPane = self.map.createPane(String(layers[0].config.id), layerPane);
-        thisLayerPane.style.zIndex = zIndex;
+        const overlayPane = self.map.getPane('overlayPane');
+        const layerPane = self.map.createPane(String(layers[0].config.id), overlayPane);
+        layerPane.style.zIndex = zIndex;
     
         var layer;
         if ( dynamicLayers ) {

--- a/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
@@ -37,10 +37,10 @@ include.module( 'layer-leaflet.layer-esri-feature-leaflet-js', [ 'layer.layer-es
                 cfg.drawingInfo.renderer.symbol.url = ( new URL( cfg.drawingInfo.renderer.symbol.url, document.location ) ).toString()
         }
 
-        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
-        const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
-        thisLayerPane.style.zIndex = zIndex;
-        cfg.pane = thisLayerPane;
+        const overlayPane = self.map.getPane('overlayPane');
+        const layerPane = self.map.createPane(layers[0].config.id, overlayPane);
+        layerPane.style.zIndex = zIndex;
+        cfg.pane = layerPane;
         
         var layer = L.esri.featureLayer( cfg )
         

--- a/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-feature-leaflet.js
@@ -37,6 +37,11 @@ include.module( 'layer-leaflet.layer-esri-feature-leaflet-js', [ 'layer.layer-es
                 cfg.drawingInfo.renderer.symbol.url = ( new URL( cfg.drawingInfo.renderer.symbol.url, document.location ) ).toString()
         }
 
+        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
+        const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
+        thisLayerPane.style.zIndex = zIndex;
+        cfg.pane = thisLayerPane;
+        
         var layer = L.esri.featureLayer( cfg )
         
         if ( layers[ 0 ].legendCacheResolve ) {
@@ -52,9 +57,6 @@ include.module( 'layer-leaflet.layer-esri-feature-leaflet-js', [ 'layer.layer-es
         }
 
         layer.on( 'load', function ( ev ) {
-            if ( layer._currentImage )
-                layer._currentImage.setZIndex( zIndex )
-
             layers[ 0 ].loading = false
         } )
 

--- a/src/smk/viewer-leaflet/layer/layer-esri-tiled-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-tiled-leaflet.js
@@ -13,6 +13,11 @@ include.module( 'layer-leaflet.layer-esri-tiled-leaflet-js', [ 'layer.layer-esri
     SMK.TYPE.Layer[ 'esri-tiled' ][ 'leaflet' ].create = function ( layers, zIndex ) {
         if ( layers.length != 1 ) throw new Error( 'only 1 config allowed' )
 
+        var self = this;
+        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
+        const thisLayerPane = self.map.createPane(String(layers[0].config.id), layerPane);
+        thisLayerPane.style.zIndex = zIndex;
+
         var serviceUrl  = layers[ 0 ].config.serviceUrl
         var opacity     = layers[ 0 ].config.opacity
 
@@ -25,13 +30,11 @@ include.module( 'layer-leaflet.layer-esri-tiled-leaflet-js', [ 'layer.layer-esri
             maxZoom = this.getZoomBracketForScale( layers[ 0 ].config.maxScale )[ 1 ]
 
         var layer = L.esri.tiledMapLayer({
-            url: serviceUrl
+            url: serviceUrl,
+            pane: thisLayerPane
         } );
         
         layer.on( 'load', function ( ev ) {
-            if ( layer._currentImage )
-                layer._currentImage.setZIndex( zIndex )
-
             layers[ 0 ].loading = false
         } )
 

--- a/src/smk/viewer-leaflet/layer/layer-esri-tiled-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-esri-tiled-leaflet.js
@@ -14,9 +14,9 @@ include.module( 'layer-leaflet.layer-esri-tiled-leaflet-js', [ 'layer.layer-esri
         if ( layers.length != 1 ) throw new Error( 'only 1 config allowed' )
 
         var self = this;
-        const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
-        const thisLayerPane = self.map.createPane(String(layers[0].config.id), layerPane);
-        thisLayerPane.style.zIndex = zIndex;
+        const tilePane = self.map.getPane('tilePane');
+        const layerPane = self.map.createPane(String(layers[0].config.id), tilePane);
+        layerPane.style.zIndex = zIndex;
 
         var serviceUrl  = layers[ 0 ].config.serviceUrl
         var opacity     = layers[ 0 ].config.opacity
@@ -31,7 +31,7 @@ include.module( 'layer-leaflet.layer-esri-tiled-leaflet-js', [ 'layer.layer-esri
 
         var layer = L.esri.tiledMapLayer({
             url: serviceUrl,
-            pane: thisLayerPane
+            pane: layerPane
         } );
         
         layer.on( 'load', function ( ev ) {

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -140,6 +140,10 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                     } )
             } )
             .then( function ( projectCoord ) {
+                const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
+                const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
+                thisLayerPane.style.zIndex = zIndex;
+                
                 var layer = new L.geoJson( null, {
                     coordsToLatLng: projectCoord,
                     pointToLayer: function ( geojson, latlng ) {
@@ -155,19 +159,13 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                             layer.setStyle( convertStyle( feature.style /* || layers[ 0 ].config.style */, feature.geometry.type ) )
                     },
                     renderer: L.svg(),
-                    interactive: false
+                    interactive: false,
+                    pane: thisLayerPane
                 } )
 
                 if ( layers[ 0 ].config.tooltip ) {
                     layer.bindTooltip( layers[ 0 ].config.tooltip.title, Object.assign( { permanent: true }, layers[ 0 ].config.tooltip.option ) )
                 }
-
-                layer.on( {
-                    add: function () {
-                        if ( layer.options.renderer._container )
-                            layer.options.renderer._container.style.zIndex = zIndex
-                    }
-                } )
 
                 if ( !layers[ 0 ].config.CRS )
                     layers[ 0 ].config.CRS = 'EPSG4326'
@@ -197,8 +195,9 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                     layer.clearLayers()
                 }
 
-                if ( layers[ 0 ].config.isInternal )
+                if ( layers[ 0 ].config.isInternal ){
                     return layer
+                }
 
                 var url = self.resolveAttachmentUrl( layers[ 0 ].config.dataUrl, layers[ 0 ].config.id, 'json' )
 

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -140,9 +140,9 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                     } )
             } )
             .then( function ( projectCoord ) {
-                const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
-                const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
-                thisLayerPane.style.zIndex = zIndex;
+                const overlayPane = self.map.getPane('overlayPane');
+                const layerPane = self.map.createPane(layers[0].config.id, overlayPane);
+                layerPane.style.zIndex = zIndex;
                 
                 var layer = new L.geoJson( null, {
                     coordsToLatLng: projectCoord,
@@ -160,7 +160,7 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                     },
                     renderer: L.svg(),
                     interactive: false,
-                    pane: thisLayerPane
+                    pane: layerPane
                 } )
 
                 if ( layers[ 0 ].config.tooltip ) {

--- a/src/smk/viewer-leaflet/layer/layer-wms-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-wms-leaflet.js
@@ -11,6 +11,8 @@ include.module( 'layer-leaflet.layer-wms-leaflet-js', [ 'layer.layer-wms-js' ], 
     // _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     //
     SMK.TYPE.Layer[ 'wms' ][ 'leaflet' ].create = function ( layers, zIndex ) {
+        var self = this;
+
         var serviceUrl  = layers[ 0 ].config.serviceUrl
         var layerNames  = layers.map( function ( c ) { return c.config.layerName } ).join( ',' )
         var styleNames  = layers.map( function ( c ) { return c.config.styleName } ).join( ',' )
@@ -20,6 +22,10 @@ include.module( 'layer-leaflet.layer-wms-leaflet-js', [ 'layer.layer-wms-js' ], 
         var where       = layers.map( function ( c ) { return c.config.where || 'include' } ).join( ';' )
 
         return resolveSLD( this, layers[ 0 ].config.sld ).then( function ( sld ) {
+            const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
+            const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
+            thisLayerPane.style.zIndex = zIndex;
+
             var layer = L.nonTiledLayer.wms( serviceUrl, {
                 layers:         layerNames,
                 styles:         styleNames,
@@ -28,8 +34,8 @@ include.module( 'layer-leaflet.layer-wms-leaflet-js', [ 'layer.layer-wms-js' ], 
                 opacity:        opacity,
                 format:         'image/png',
                 transparent:    true,
-                zIndex:         zIndex,
-                cql_filter:     where
+                cql_filter:     where,
+                pane:           thisLayerPane
             } )
     
             if ( sld ) {

--- a/src/smk/viewer-leaflet/layer/layer-wms-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-wms-leaflet.js
@@ -22,9 +22,9 @@ include.module( 'layer-leaflet.layer-wms-leaflet-js', [ 'layer.layer-wms-js' ], 
         var where       = layers.map( function ( c ) { return c.config.where || 'include' } ).join( ';' )
 
         return resolveSLD( this, layers[ 0 ].config.sld ).then( function ( sld ) {
-            const layerPane = self.map.getPane(SMK.TYPE.Viewer.leaflet.prototype.layerPane);
-            const thisLayerPane = self.map.createPane(layers[0].config.id, layerPane);
-            thisLayerPane.style.zIndex = zIndex;
+            const overlayPane = self.map.getPane('overlayPane');
+            const layerPane = self.map.createPane(layers[0].config.id, overlayPane);
+            layerPane.style.zIndex = zIndex;
 
             var layer = L.nonTiledLayer.wms( serviceUrl, {
                 layers:         layerNames,
@@ -35,7 +35,7 @@ include.module( 'layer-leaflet.layer-wms-leaflet-js', [ 'layer.layer-wms-js' ], 
                 format:         'image/png',
                 transparent:    true,
                 cql_filter:     where,
-                pane:           thisLayerPane
+                pane:           layerPane
             } )
     
             if ( sld ) {

--- a/src/smk/viewer-leaflet/viewer-leaflet.js
+++ b/src/smk/viewer-leaflet/viewer-leaflet.js
@@ -2,6 +2,7 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
     "use strict";
 
     const BASEMAP_PANE = 'basemaps';
+    const LAYER_PANE = 'layers';
 
     function ViewerLeaflet() {
         SMK.TYPE.Viewer.prototype.constructor.apply( this, arguments )
@@ -13,6 +14,8 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
     $.extend( ViewerLeaflet.prototype, SMK.TYPE.Viewer.prototype )
     // _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     //
+    ViewerLeaflet.prototype.layerPane = LAYER_PANE;
+
     ViewerLeaflet.prototype.initialize = function ( smk ) {
         var self = this
 
@@ -35,6 +38,11 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
         // Create a panel for basemaps with a low z-index to ensure they draw below layers
         self.map.createPane(BASEMAP_PANE);
         self.map.getPane(BASEMAP_PANE).style.zIndex = 100;
+
+        // Create a panel for layers with a z-index that doesn't interfere with other Leaflet pane z-indices
+        // (https://leafletjs.com/reference.html#map-pane)
+        self.map.createPane(LAYER_PANE);
+        self.map.getPane(LAYER_PANE).style.zIndex = 300;
 
         self.map.scrollWheelZoom.disable()
 

--- a/src/smk/viewer-leaflet/viewer-leaflet.js
+++ b/src/smk/viewer-leaflet/viewer-leaflet.js
@@ -2,7 +2,6 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
     "use strict";
 
     const BASEMAP_PANE = 'basemaps';
-    const LAYER_PANE = 'layers';
 
     function ViewerLeaflet() {
         SMK.TYPE.Viewer.prototype.constructor.apply( this, arguments )
@@ -14,8 +13,6 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
     $.extend( ViewerLeaflet.prototype, SMK.TYPE.Viewer.prototype )
     // _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     //
-    ViewerLeaflet.prototype.layerPane = LAYER_PANE;
-
     ViewerLeaflet.prototype.initialize = function ( smk ) {
         var self = this
 
@@ -38,11 +35,6 @@ include.module( 'viewer-leaflet', [ 'viewer', 'leaflet', 'layer-leaflet', /*'fea
         // Create a panel for basemaps with a low z-index to ensure they draw below layers
         self.map.createPane(BASEMAP_PANE);
         self.map.getPane(BASEMAP_PANE).style.zIndex = 100;
-
-        // Create a panel for layers with a z-index that doesn't interfere with other Leaflet pane z-indices
-        // (https://leafletjs.com/reference.html#map-pane)
-        self.map.createPane(LAYER_PANE);
-        self.map.getPane(LAYER_PANE).style.zIndex = 300;
 
         self.map.scrollWheelZoom.disable()
 

--- a/src/smk/viewer.js
+++ b/src/smk/viewer.js
@@ -474,20 +474,22 @@ include.module( 'viewer', [ 'jquery', 'util', 'event', 'layer', 'feature-set', '
             visibleLayers.push( merged )
 
         var promises = []
-        var maxZOrder = visibleLayers.length - 1
-        visibleLayers.forEach( function ( lys, i ) {
+        var maxZOrder = visibleLayers.length
+        var zIndex = 0;
+        visibleLayers.forEach( function (lys) {
+            zIndex += 1;
             var cid = lys.map( function ( ly ) { return ly.id } ).join( '##' )
 
             delete pending[ cid ]
             if ( self.visibleLayer[ cid ] ) {
-                self.positionViewerLayer( self.visibleLayer[ cid ], maxZOrder - i )
+                self.positionViewerLayer( self.visibleLayer[ cid ], zIndex )
                 return
             }
 
-            var p = self.createViewerLayer( cid, lys, maxZOrder - i )
+            var p = self.createViewerLayer( cid, lys, zIndex )
                 .then( function ( ly ) {
                     self.addViewerLayer( ly )
-                    self.positionViewerLayer( ly, maxZOrder - i )
+                    self.positionViewerLayer( ly, zIndex )
                     self.visibleLayer[ cid ] = ly
                     return ly
                 } )


### PR DESCRIPTION
This improves the ordering of layers as they display when an SMK app is first loaded. The layer order follows the order of the 'display' section of SMK config for the layers tool EXCEPT GeoJSON/'vector' layers still appear on top.

This adds a 'layers' pane with a z-index of 300 to avoid conflict with other standard layers used by Leaflet. The zIndex assigned from visible layers in viewer.js is corrected to increase on iteration. Code for Leaflet layers is updated to create a new pane for each layer and set each layer's style on the zIndex from view.js.