### PR TITLE
Vector/GeoJSON layer can be conditionally styled

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -168,11 +168,8 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                                 console.debug(`The feature property ${conditionalStyle.property} was not found; conditional styling will not be applied for this property.`);
                                 return convertStyle(combinedStyle, feature.geometry.type);
                             }
-                            conditionalStyle.conditions.forEach(condition => {
-                                if (condition.value === feature.properties[conditionalStyle.property]) {
-                                    Object.assign(combinedStyle, condition.style);
-                                    return;
-                                }
+                            conditionalStyle.conditions.filter(condition => condition.value === feature.properties[conditionalStyle.property]).forEach(condition => {
+                                Object.assign(combinedStyle, condition.style);
                             });
                         });
                         return convertStyle(combinedStyle, feature.geometry.type);


### PR DESCRIPTION
Hi Darren. This changeset is a bit rough but I wanted to get early feedback on it.

This changeset is in response to CleanBC requests to style shapes differently based on feature values. A specific use case is changing colour based on charging station stall type. I have a WIP branch for this at https://github.com/bcgov/smk-clean-bc/tree/wip_geojson_conditional_styling.

First, please let me know if you know of a simpler way to do this - maybe there's something I'm missing as I don't have your experience with what is done and can be done with web mapping. Or perhaps there's good reason why we shouldn't even consider it? 

I've also changed the way styling is done for this layer type - instead of applying a style to the layer, it's applied functionally to each shape. 

We may want to do this for other layer types - Esri feature layers may be in scope for this - so I anticipate doing further work to see if we can abstract this out for better reuse.

There's also an issue with the legend as it will only show one style at present. Currently it will use values in the "style" element of layer configuration (ignoring overrides in the new "conditionalStyles" element). I may look into updating legend code for this layer.