### PR TITLE
Improvements to GeoJSON layer conditional styling

### DIFF
--- a/docs/configuration/layers/vector.md
+++ b/docs/configuration/layers/vector.md
@@ -74,7 +74,18 @@ The [style object](style) used to render the features from this data source.
 
 Style attributes applied to features based on feature attribute values. These style attributes override style attributes with the same name in the `style` property.
 
-Each conditional style has a `property`, which is the name of a feature attribute, and `conditions`, an array of objects containing a `value`, which is the value of the `property` attribute, and a `style` object. 
+Each conditional style has a `property`, which is the name of a feature attribute, and `conditions`, an array of objects containing: 
+
+- `value`: the value of the feature's `property` attribute
+- `style`: an object of style properties and values
+- `operator`: an optional operator to use to compare the condition value to the feature's property value. Operators are:
+    - `>` greater than, for number values 
+    - `>=` greater than or equal to, for number values 
+    - `<` less than, for number values 
+    - `<=` less than or equal to, for number values 
+    - `exists` a value exists (is not null or undefined)
+    - `!=` not equal to 
+    - `=` equal. This is also the default if no operator is given.
 
 In this sample configuration, features having a `Station_Type` value of `Public` will be styled as blue, and features where `Station_Type` is `Private` will be styled as green.
 
@@ -101,6 +112,24 @@ In this sample configuration, features having a `Station_Type` value of `Public`
     }
 ]
 ```
+
+This sample configuration styles features having a `Charging_Level` value of 2 or higher with a white stroke color:
+
+``` 
+"conditionalStyles": [
+    {
+        "property": "Charging_Level",
+        "conditions": [
+            {
+                "operator": ">=",
+                "value": 2,
+                "style": {
+                    "strokeColor": "#ffffff"
+                }
+            }
+        ]
+    }
+]
 
 ## DataUrl Property
 `"dataUrl": String`

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -168,7 +168,7 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                                 console.debug(`The feature property ${conditionalStyle.property} was not found; conditional styling will not be applied for this property.`);
                                 return convertStyle(combinedStyle, feature.geometry.type, layerPaneId);
                             }
-                            conditionalStyle.conditions.filter(condition => condition.value === feature.properties[conditionalStyle.property]).forEach(condition => {
+                            conditionalStyle.conditions.filter(condition => matches(feature.properties[conditionalStyle.property], condition)).forEach(condition => {
                                 Object.assign(combinedStyle, condition.style);
                             });
                         });
@@ -303,6 +303,19 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                 pane:        layerPaneId
                 // fillRule:    styleConfig.,
             }
+    }
+
+    function matches(value, condition) {
+        switch(condition.operator) {
+            case '>': return !Number.isNaN(value) && value > condition.value;
+            case '>=': return !Number.isNaN(value) && value >= condition.value;
+            case '<': return !Number.isNaN(value) && value < condition.value;
+            case '<=': return !Number.isNaN(value) && value <= condition.value;
+            case '!=': return value !== condition.value;
+            case 'exists': return value !== null && value !== undefined;
+            case '=': return value === condition.value;
+            default: return value === condition.value;
+        }
     }
 
     function markerForStyle( viewer, latlng, styleConfig, layerConfig ) {

--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -165,7 +165,7 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                         var combinedStyle = Object.assign({}, defaultStyle);
                         layers[0].config.conditionalStyles.forEach(conditionalStyle => {
                             if (!Object.keys(feature.properties).includes(conditionalStyle.property)) {
-                                console.debug(`The feature property ${conditionalStyle.property} was not found; conditional styling will not be applied for this property.`);
+                                console.warn(`The feature property ${conditionalStyle.property} was not found; conditional styling will not be applied for this property.`);
                                 return convertStyle(combinedStyle, feature.geometry.type, layerPaneId);
                             }
                             conditionalStyle.conditions.filter(condition => matches(feature.properties[conditionalStyle.property], condition)).forEach(condition => {
@@ -307,15 +307,23 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
 
     function matches(value, condition) {
         switch(condition.operator) {
-            case '>': return !Number.isNaN(value) && value > condition.value;
-            case '>=': return !Number.isNaN(value) && value >= condition.value;
-            case '<': return !Number.isNaN(value) && value < condition.value;
-            case '<=': return !Number.isNaN(value) && value <= condition.value;
+            case '>': return validateNumber(value) && value > condition.value;
+            case '>=': return validateNumber(value) && value >= condition.value;
+            case '<': return validateNumber(value) && value < condition.value;
+            case '<=': return validateNumber(value) && value <= condition.value;
             case '!=': return value !== condition.value;
             case 'exists': return value !== null && value !== undefined;
             case '=': return value === condition.value;
             default: return value === condition.value;
         }
+    }
+
+    function validateNumber(value) {
+        if (Number.isNaN(parseFloat(value))) {
+            console.warn(`The feature value ${value} is not a number and cannot be used in a numerical comparison. This comparison will be ignored.`);
+            return false;
+        }
+        return true;
     }
 
     function markerForStyle( viewer, latlng, styleConfig, layerConfig ) {


### PR DESCRIPTION
This introduces operators to the conditional styling syntax to allow comparisons beyond equals. Equals is used as the default to maintain backwards compatibility.

Documentation for vector/GeoJSON layer configuration is also updated.