### PR TITLE
Add null check when validating numbers

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -319,7 +319,7 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
     }
 
     function validateNumber(value) {
-        if (Number.isNaN(parseFloat(value))) {
+        if (value && Number.isNaN(parseFloat(value))) {
             console.warn(`The feature value ${value} is not a number and cannot be used in a numerical comparison. This comparison will be ignored.`);
             return false;
         }


### PR DESCRIPTION
When applying a numerical comparison to a feature value that can be null, null values trigger a console warning on null values instead of just non-number values. This can result in hundreds of extra console warnings.