### PR TITLE
Vector layer can hide layer symbology when conditional styling used

### DIFF
--- a/docs/configuration/layers/vector.md
+++ b/docs/configuration/layers/vector.md
@@ -145,9 +145,9 @@ Optional attributes to configure the display of the layer in legends.
 
 Set the shape of the legend swatch. "line" is the default. 
 
-`"includeOtherLegendWithDefaultStyling": Boolean`
+`"excludeOtherLegendWithDefaultStyling": Boolean`
 
-When <a href="#conditionalstyles-property">conditional styles</a> are used, set this to true to add an "Other" legend with a swatch using the styling in the <a href="#style-property">style</a> to represent features that are not matched by any of the conditions defined in conditional styling.
+By default, when <a href="#conditionalstyles-property">conditional styles</a> are used, an "Other" legend will be added with a swatch using the styling in the <a href="#style-property">style</a> to represent features that are not matched by any of the conditions. Set `excludeOtherLegendWithDefaultStyling` to true to exclude the "Other" legend for situations where all of a layer's features will be matched by the conditions and an "Other" legend is not necessary.
 
 ## DataUrl Property
 `"dataUrl": String`

--- a/docs/configuration/layers/vector.md
+++ b/docs/configuration/layers/vector.md
@@ -23,7 +23,8 @@ Click on a property name for more information:
     <a href="#clusteroption-property"       >"clusterOption"</a>:       null,
     <a href="#useheatmap-property"          >"useHeatmap"</a>:          false,
     <a href="#style-property"               >"style"</a>:               null,
-    <a href="#conditionalstyles-property"  >"conditionalStyles"</a>:   null,
+    <a href="#conditionalstyles-property"   >"conditionalStyles"</a>:   null,
+    <a href="#legend-property"              >"legend"</a>:              null,
     <a href="#dataUrl-property"             >"dataUrl"</a>:             null
 } ] }
 </pre>
@@ -62,7 +63,6 @@ The [cluster option](cluster-option) object used to influence the rendering of c
 If `true`, the layer should use heatmap clustering.
 Only relevant for point geometry layers.
 The default is `false`.
-
 
 ## Style Property
 `"style": Object | Array`
@@ -135,6 +135,19 @@ This sample configuration styles features having a `Charging_Level` value of 3 o
     }
 ]
 ```
+
+## Legend Property
+`"legend": Object`
+
+Optional attributes to configure the display of the layer in legends.
+
+`"point", "line", "fill": Boolean`
+
+Set the shape of the legend swatch. "line" is the default. 
+
+`"includeOtherLegendWithDefaultStyling": Boolean`
+
+When <a href="#conditionalstyles-property">conditional styles</a> are used, set this to true to add an "Other" legend with a swatch using the styling in the <a href="#style-property">style</a> to represent features that are not matched by any of the conditions defined in conditional styling.
 
 ## DataUrl Property
 `"dataUrl": String`

--- a/src/smk/layer/layer-vector.js
+++ b/src/smk/layer/layer-vector.js
@@ -25,7 +25,7 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
         legendData.push({
             title: self.config.legend && self.config.legend.title || self.config.title,
             style: self.config.style,
-            hasConditionalStyling: self.config.conditionalStyles || false
+            hasConditionalStyling: 'conditionalStyles' in self.config
         });
 
         if (self.config.conditionalStyles) {
@@ -41,7 +41,7 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
                     });
                 });
             });
-            if (self.config.legend.includeOtherLegendWithDefaultStyling) {
+            if (!self.config.legend.excludeOtherLegendWithDefaultStyling) {
                 legendData.push({
                     title: "Other",
                     style: self.config.style,

--- a/src/smk/layer/layer-vector.js
+++ b/src/smk/layer/layer-vector.js
@@ -25,7 +25,7 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
         legendData.push({
             title: self.config.legend && self.config.legend.title || self.config.title,
             style: self.config.style,
-            hideLayer: (self.config.conditionalStyles && self.config.legend.hideLayer) || false
+            hasConditionalStyling: self.config.conditionalStyles || false
         });
 
         if (self.config.conditionalStyles) {
@@ -41,6 +41,13 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
                     });
                 });
             });
+            if (self.config.legend.includeOtherLegendWithDefaultStyling) {
+                legendData.push({
+                    title: "Other",
+                    style: self.config.style,
+                    indent: true
+                });
+            }
         }
 
         return SMK.UTIL.resolved( 0 )

--- a/src/smk/layer/layer-vector.js
+++ b/src/smk/layer/layer-vector.js
@@ -24,7 +24,8 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
         const legendData = [];
         legendData.push({
             title: self.config.legend && self.config.legend.title || self.config.title,
-            style: self.config.style
+            style: self.config.style,
+            hideLayer: (self.config.conditionalStyles && self.config.legend.hideLayer) || false
         });
 
         if (self.config.conditionalStyles) {

--- a/src/smk/tool/layers/layer-display.html
+++ b/src/smk/tool/layers/layer-display.html
@@ -36,6 +36,7 @@
         >
             <div class="smk-legend-item"
                 v-for="legend in display.legends"
+                v-if="!legend.hideLayer"
             >
                 <span v-if="legend.indent" class="smk-legend-item-indent"></span>
                 <img v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">

--- a/src/smk/tool/layers/layer-display.html
+++ b/src/smk/tool/layers/layer-display.html
@@ -36,7 +36,7 @@
         >
             <div class="smk-legend-item"
                 v-for="legend in display.legends"
-                v-if="!legend.hideLayer"
+                v-if="!legend.hasConditionalStyling"
             >
                 <span v-if="legend.indent" class="smk-legend-item-indent"></span>
                 <img v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">

--- a/src/smk/tool/legend/legend-display.html
+++ b/src/smk/tool/legend/legend-display.html
@@ -23,7 +23,7 @@
                 v-for="legend in display.legends"
             >
                 <span v-if="legend.indent" class="smk-legend-item-indent"></span>
-                <img v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">
+                <img v-if="!legend.hideLayer" v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">
                 <span class="smk-legend-title">{{ legend.title }}</span>
             </div>
         </div>

--- a/src/smk/tool/legend/legend-display.html
+++ b/src/smk/tool/legend/legend-display.html
@@ -23,7 +23,7 @@
                 v-for="legend in display.legends"
             >
                 <span v-if="legend.indent" class="smk-legend-item-indent"></span>
-                <img v-if="!legend.hideLayer" v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">
+                <img v-if="!legend.hasConditionalStyling" v-bind:src="legend.url" v-bind:style="{ width: legend.width + 'px', height: legend.height + 'px' }">
                 <span class="smk-legend-title">{{ legend.title }}</span>
             </div>
         </div>

--- a/src/smk/tool/legend/tool-legend.css
+++ b/src/smk/tool/legend/tool-legend.css
@@ -48,3 +48,8 @@
     display: none;
 }
 
+.smk-legend-status .smk-display.smk-display-folder {
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 5px;
+}


### PR DESCRIPTION
In some uses of conditional styling, styling is applied to feature values in a way that each feature is included and matches one style, similar to a pie chart. In such situations, including a style for the entire layer in a legend is unnecessary.

This adds a "hideLayer" property to legend configuration in vector layers and to legend display HTML. When added to a vector/GeoJSON layer's legend configuration and set to true, the symbology for the layer (but not its conditional styling) is omitted in the legends.