### PR TITLE
Route path restyled

### DIFF
--- a/src/smk/tool/directions/config/tool-directions-config.js
+++ b/src/smk/tool/directions/config/tool-directions-config.js
@@ -31,7 +31,7 @@ include.module( 'tool-directions-config', [
                     title: "Segments",
                     style: {
                         strokeColor: "blue",
-                        strokeWidth: 8,
+                        strokeWidth: 6,
                         strokeOpacity: 0.8
                     },
                     legend: {
@@ -42,7 +42,8 @@ include.module( 'tool-directions-config', [
                     id: "@segments-after-range-limit",
                     title: "Segments After Range Limit",
                     style: {
-                        strokeColor: "lightblue",
+                        strokeColor: "blue",
+                        strokeDashes: "10,5",
                         strokeWidth: 4,
                         strokeOpacity: 0.8
                     },


### PR DESCRIPTION
This restyles the route path segments based on design advice. There is less of a difference in path width, and the colour is the same before and after range limit is met, but the path after range limit uses a dashed line instead of a solid line.