### PR TITLE
Can override Other legend label

### DIFF
--- a/docs/configuration/layers/vector.md
+++ b/docs/configuration/layers/vector.md
@@ -149,6 +149,10 @@ Set the shape of the legend swatch. "line" is the default.
 
 By default, when <a href="#conditionalstyles-property">conditional styles</a> are used, an "Other" legend will be added with a swatch using the styling in the <a href="#style-property">style</a> to represent features that are not matched by any of the conditions. Set `excludeOtherLegendWithDefaultStyling` to true to exclude the "Other" legend for situations where all of a layer's features will be matched by the conditions and an "Other" legend is not necessary.
 
+`"otherLegendLabelOverride": String`
+
+A string value to display instead of "Other" when <a href="#conditionalstyles-property">conditional styles</a> are used.
+
 ## DataUrl Property
 `"dataUrl": String`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/smk",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/smk",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "APSL-2.0",
       "devDependencies": {
         "browser-sync": "~2.27.11",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.9",
+  "version": "1.1.10",
   "name": "@bcgov/smk",
   "title": "Simple Map Kit",
   "description": "A simple way to add a map your application.",

--- a/src/smk/layer/layer-vector.js
+++ b/src/smk/layer/layer-vector.js
@@ -43,7 +43,7 @@ include.module( 'layer.layer-vector-js', [ 'layer.layer-js' ], function () {
             });
             if (!self.config.legend.excludeOtherLegendWithDefaultStyling) {
                 legendData.push({
-                    title: "Other",
+                    title: self.config.legend.otherLegendLabelOverride ? self.config.legend.otherLegendLabelOverride : "Other",
                     style: self.config.style,
                     indent: true
                 });


### PR DESCRIPTION
This adds an optional configuration parameter to vector/GeoJSON layers to replace "Other" as a legend label when conditional styling is used.

Documentation for the vector layer type is also updated.

This also increments SMK's version.