### PR TITLE
Reinstate vector onEachFeature function

### DIFF
--- a/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
+++ b/src/smk/viewer-leaflet/layer/layer-vector-leaflet.js
@@ -148,7 +148,6 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                 var layerOptions = {
                     coordsToLatLng: projectCoord,
                     pointToLayer: function ( geojson, latlng ) {
-                        // return markerForStyle( self, latlng, layers[ 0 ].config.style )
                         return markerForStyle( self, latlng, styles[ 0 ], layers[ 0 ].config )
                             .on( 'moveend', function ( ev ) {
                                 var ll = ev.target.getLatLng()
@@ -174,10 +173,16 @@ include.module( 'layer-leaflet.layer-vector-leaflet-js', [ 'layer.layer-vector-j
                         });
                         return convertStyle(combinedStyle, feature.geometry.type, layerPaneId);
                     };
+                } else if (layers[0].config.isInternal) {
+                    layerOptions.onEachFeature = function ( feature, layer ) {
+                        if (layer.setStyle) {
+                            layer.setStyle(convertStyle(feature.style, feature.geometry.type));
+                        }
+                    };
                 } else {
                     layerOptions.style = function(feature) {
                         return convertStyle(layers[0].config.style, feature.geometry.type, layerPaneId);
-                    }
+                    };
                 }
 
                 var layer = new L.geoJson(null, layerOptions);


### PR DESCRIPTION
This restores the onEachFeature function to vector layer options for internal layers. It was removed in SMK 1.1.6 when changes were made to support conditional styling. When a radius is used with the Identify tool, its styling is lost and the radius draws as a black circle; this change restores prior radius styling.

Further explanation (the paragraph above will be the commit message):

I noticed this when working on the new Children & Youth Mental Health (CYMH) app, which will be similar to the Mental Health and Substance Use (MHSU) app. MHSU's Identify tool configuration uses a radius, and I noticed that when I use a newer version of SMK, the radius draws as a black circle. 

The bug was introduced in https://github.com/bcgov/smk/pull/207/commits/aeae0b5bc65234bf38f2d03cfaa4ff776ed59be1 where the "onEachFeature" function was removed. 

For layers, we should continue to apply styling by setting the "style" option; if we use the onEachFeature function instead, we lose the layer reference in the style, and layer ordering is lost. 

I thought it best to discern the Identify tool layer by using the "isInternal" property as opposed to something more specific, for example by discerning on layer id "@identify-search-area". 

I've tested this in multiple SMK apps with multiple layer types and confirmed that layer order and styling are preserved while Identify tool styling is restored.