### PR TITLE
Directions zooms to route extent

### DIFF
--- a/src/smk/tool/directions/tool-directions-waypoints.js
+++ b/src/smk/tool/directions/tool-directions-waypoints.js
@@ -59,6 +59,8 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
             this.routePlanner = new SMK.TYPE.RoutePlanner( this.routePlannerService )
             this.geocoder = new SMK.TYPE.Geocoder( this.geocoderService )
 
+            this.map = smk.$viewer.map;
+
             this.changedActive( function () {
                 if ( self.active ) {
                     // if ( self.waypoints.length == 0 ) {
@@ -371,6 +373,10 @@ include.module( 'tool-directions.tool-directions-waypoints-js', [
                         sg.style = self.layer[ ly ].config.style
                     } )
                 } )
+
+                const bbox = turf.bbox(segments);
+                const latLngBounds = L.latLngBounds({lng: bbox[0], lat: bbox[1]}, {lng: bbox[2], lat: bbox[3]});
+                self.map.flyToBounds(latLngBounds, {padding: [100,100]});
             },
 
             displayWaypoints: function () {


### PR DESCRIPTION
When a route is first displayed, or its waypoints change, the map extent doesn't change, and users often need to zoom in to the route to see it clearly. This change gets a bounding box for all route segments and zooms to the corners of the bounding box (plus some padding).