### PR TITLE
Update query-place.js

### DIFF
--- a/src/smk/query/query-place.js
+++ b/src/smk/query/query-place.js
@@ -35,7 +35,7 @@ include.module( 'query.query-place-js', [ 'query.query-js' ], function () {
             $.ajax( {
                 timeout:    10 * 1000,
                 dataType:   'jsonp',
-                url:        'https://apps.gov.bc.ca/pub/geocoder/addresses.geojsonp',
+                url:        'https://geocoder.api.gov.bc.ca/addresses.geojsonp',
                 data:       query,
             } ).then( res, rej )
         } )


### PR DESCRIPTION
Code update for your review and testing. A single change made to query-place.js to replace the deprecated Geocoder endpoint (apps.gov.bc.ca) with the new Geocoder endpoint (api.gov.bc.ca).
