### PR TITLE
Comment out link to nonfunctional Measure tool in Tool-Config page (MAP-8694)

### DIFF
--- a/debug/feature/Tool-Config/index.html
+++ b/debug/feature/Tool-Config/index.html
@@ -12,7 +12,8 @@
 
         <script>
             addExample( 'markup' )
-            addExample( 'measure' )
+            // Measure is commented out as it no longer works after a Leaflet update (https://github.com/bcgov/smk/pull/188)
+            // addExample( 'measure' )
             addExample( 'select' )
         </script>
     </body>


### PR DESCRIPTION
This removes a link to a page demonstrating the Measure tool. The Measure tool stopped working when Leaflet was updated in https://github.com/bcgov/smk/pull/188, and it was some time before we even noticed.

To view this page, run "npm run start" from the root of the smk repository; this will launch a browser window at port 3000 showing page "SMK Debug". Navigate to "Features" and then "Tool Config". This change removes the link to the "Measure" page.
