### PR TITLE
Mini Map tool uses BC Government Hillshade basemap (MAP-8838)

### DIFF
--- a/src/smk/viewer-leaflet/tool/minimap/tool-minimap-leaflet.js
+++ b/src/smk/viewer-leaflet/tool/minimap/tool-minimap-leaflet.js
@@ -6,7 +6,7 @@ include.module( 'tool-minimap-leaflet', [ 'leaflet', 'tool-minimap' ], function 
 
         smk.addToStatus( $( '<div class="smk-spacer">' ).height( 170 ).get( 0 ) )
 
-        var ly = smk.$viewer.createBasemapLayer( this.baseMap || "Topographic", smk.viewer.esriApiKey );
+        var ly = smk.$viewer.createBasemapLayer( this.baseMap || "BCGovHillshade" );
 
         ( new L.Control.MiniMap( ly[ 0 ], { toggleDisplay: true } ) )
             .addTo( smk.$viewer.map );


### PR DESCRIPTION
This updates the Mini Map tool to use a non-Esri basemap instead of Esri's Topographic basemap. This prevents an error dialog regarding a missing Esri API key for SMK apps that have a non-Esri basemap but use the Mini Map tool.
