### PR TITLE
Add feedback link to README (MAP-8809)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ It also gives you an interactive web-based UI to do more detailed configuration 
 
 To see some samples of SMK in action, you can look at the [debug folder](https://bcgov.github.io/smk/debug).
 
+# Feedback
+Report a bug, request an enhancement, or provide feedback at https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/1.
+
 # License
 ```
 Copyright 2026 Province of British Columbia

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It also gives you an interactive web-based UI to do more detailed configuration 
 To see some samples of SMK in action, you can look at the [debug folder](https://bcgov.github.io/smk/debug).
 
 # Feedback
-Report a bug, request an enhancement, or provide feedback at https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/1.
+Report a bug, request an enhancement, or provide feedback at the [Data System and Services Portal](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/1).
 
 # License
 ```


### PR DESCRIPTION
This adds a link to our JSM portal for users to leave feedback. 

I expect to use the same link and text in a subsequent change to the SMK-CLI README page.

I deliberately didn't add link text (that would appear instead of the raw URL, for example "Feedback page") because I couldn't think of a good value and I think it might be just fine without link text. The page linked to has the title "Data Systems & Services" - that was my first thought. I'm very open to suggestions. The link itself was suggested by Caitlin over a more specific path - see her comment in MAP-8809.

If you're not familiar with Markdown syntax, a good reference is https://www.markdownguide.org/basic-syntax/. 